### PR TITLE
Feat: Exit button in menu closes the application

### DIFF
--- a/MainScreen.js
+++ b/MainScreen.js
@@ -28,7 +28,7 @@ export default class MainScreen {
         <span class="auto btn">Auto Play</span>
         <span class="load btn">Load</span>
         <span class="rank btn">Ranking</span>
-        <span class="btn">Exit</span>
+        <span class="btn" onclick="window.open('', '_self', ''); window.close();">Exit</span>
     `;
     this.$target.innerHTML = ``;
     this.$target.appendChild(this.$screen);


### PR DESCRIPTION
As explained in existing issue : https://github.com/myeongbaek/SnakeGame_Team07/issues/5
The main window didn't close when clicking the "Exit" button.

Most of the browsers doesn't allow javascript to close a window not opened by javascript.

A simple work around is to make javascript re-open the window and immediatly closing it.

This solution might not be working on every browsers but works on Edge and most of Chrome versions.

Here is the solution provided:
```html
<span class="btn" onclick="window.open('', '_self', ''); window.close();">Exit</span>
```